### PR TITLE
Fix camera interactor style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 # MOLDE
-**M**OPT **L**ightweight **De**esign (MOLDE) is a library created to standardize and make easier the creation and maintainance of internal products of the Multidisciplinary Optimization Group (MOPT).
+**MO**PT **L**ightweight **De**sign (MOLDE) is a library created to standardize and make easier the creation and maintainance of internal products of the Multidisciplinary Optimization Group (MOPT).
 
 Here are the colors, icons, fonts and common interface components, that may be usefull for multiple MOPT projects.
 

--- a/molde/interactor_styles/box_selection_style.py
+++ b/molde/interactor_styles/box_selection_style.py
@@ -15,17 +15,17 @@ class BoxSelectionInteractorStyle(ArcballCameraInteractorStyle):
         self._saved_pixels = vtkUnsignedCharArray()
         self.selection_color = (255, 0, 0, 255)
 
-    def _left_button_press_event(self, obj, event):
-        super()._left_button_press_event(obj, event)
+    def left_button_press_event(self, obj, event):
+        super().left_button_press_event(obj, event)
         self._click_position = self.GetInteractor().GetEventPosition()
         self.start_selection()
 
-    def _left_button_release_event(self, obj, event):
-        super()._left_button_release_event(obj, event)
+    def left_button_release_event(self, obj, event):
+        super().left_button_release_event(obj, event)
         self.stop_selection()
 
-    def _mouse_move_event(self, obj, event):
-        super()._mouse_move_event(obj, event)
+    def mouse_move_event(self, obj, event):
+        super().mouse_move_event(obj, event)
         self._mouse_position = self.GetInteractor().GetEventPosition()
         self.update_selection()
 


### PR DESCRIPTION
This PR refactors the `ArcballCameraInteractorStyle` and the `BoxSelectionInteractorStyle` to enable the render tools functionality on Vibra and Open Pulse.

The idea was simple: I just created some new methods to encapsulate the logic of the common interactor style. Now, if we want to create a new tool, we just need to specialize a few methods.